### PR TITLE
Parallelize

### DIFF
--- a/src/updatedb.py
+++ b/src/updatedb.py
@@ -310,6 +310,22 @@ def parseResults(args):
     logging.info('Downloading completed')
     db_queue.join()
 
+    #Sometimes the parent may exit and the child is not immidiately killed.
+    #This may result in the error like the following -
+    #
+    #Exception in thread DBHandler (most likely raised during interpreter shutdown):
+    #Traceback (most recent call last):
+    #File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
+    #File "updatedb.py", line 120, in run
+    #File "/usr/lib/python2.7/Queue.py", line 168, in get
+    #File "/usr/lib/python2.7/threading.py", line 332, in wait
+    #: 'NoneType' object is not callable
+    #
+    #The following line works as a fix
+    #ref : http://b.imf.cc/blog/2013/06/26/python-threading-and-queue/
+
+    time.sleep(0.1)
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Update ouija database.')
     parser.add_argument('--branch', dest='branch', default='all',


### PR DESCRIPTION
Created separate threads for database handling and uploading.
### Design
- `DBHandler` thread  handles database operations. A single instance of it waits for jobs on `db_queue`.
-  `Downloader` thread(s) handle downloading jobs. Each downloader takes a job from `download_queue` downloads it and puts the data on the `db_queue` for uploading
- The main thread waits for `download_queue` to complete and then waits for the `db_queue` to complete and then exits.
### Please note
- Occasionally, the program would not terminate cleanly on gakiwate's system (I did not encounter this problem). On searching for the error on the internet I found this link http://b.imf.cc/blog/2013/06/26/python-threading-and-queue/ (its in Chinese). This link suggests a workaround. I have added that workaround and gakiwate hasn't encountered the problem since then. Details are documented in the code. 
- Usage of `join` prevents the use of `CTRL+C` to terminate the program. 
- If an exception is raised in one of the child threads, the exception will be printed and the program will continue.
##### Other changes

I was tempted to use the thread-safe logging module for printing the error and download messages. Apart from that -
- Added thread name to the download messages
- Print a `Download completed` message on download completion ( so that the database delay is noticeable ). 
