### PR TITLE
Change log messages to avoid string format TypeError.

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -129,7 +129,7 @@ def binify(bins, data):
 @json_response
 def run_resultstimeseries_query():
     platform = request.args.get("platform", "android4.0")
-    app.logger.debug('platform: ', platform)
+    app.logger.debug("platform: %s" % platform)
 
     db = create_db_connnection()
     cursor = db.cursor()
@@ -314,9 +314,13 @@ def run_platform_query():
     platform = request.args.get("platform")
     start_date, end_date = clean_date_params(request.args)
 
-    app.logger.debug('platform', platform,
-                     "startDate:", start_date.strftime('%Y-%m-%d'),
-                     "endDate:", end_date.strftime('%Y-%m-%d'))
+    log_message = """
+        platform: %s
+        startDate: %s
+        endDate: %s
+        """ % (platform, start_date.strftime('%Y-%m-%d'), end_date.strftime('%Y-%m-%d'))
+
+    app.logger.debug(log_message)
 
     db = create_db_connnection()
     cursor = db.cursor()
@@ -363,7 +367,7 @@ def run_platform_query():
             elif res == 'usercancel':
                 app.logger.debug('usercancel')
             else:
-                app.logger.debug('UNRECOGNIZED RESULT: ', result)
+                app.logger.debug('UNRECOGNIZED RESULT: %s' % result)
             dates.append(date)
 
         cset_summaries.append(cset_summary)


### PR DESCRIPTION
Was getting the following errors from the Flask logger:

```
127.0.0.1 - - [18/Jul/2014 01:33:56] "GET /data/results/?platform=android4.0 HTTP/1.1" 200 -
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 851, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 724, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 464, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 328, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Logged from file server.py, line 132
```

---

```
127.0.0.1 - - [18/Jul/2014 01:34:26] "GET /data/platform?platform=android4.0 HTTP/1.1" 301 -
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 851, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 724, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 464, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 328, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Logged from file server.py, line 319
```

Feel free to merge if you have this problem as well =)
