### PR TITLE
Bug 1009198 - Add previous week data to Ouija wiki_update page.

### DIFF
--- a/static/wiki_update.html
+++ b/static/wiki_update.html
@@ -34,8 +34,9 @@
 
             }
             request.open('get', '/data/platform?platform='+android_version+'&startdate='+s_last_week + '&enddate=' + s_today, true);
+            request.send();
             document.writeln("* " +android_version+" Total failure exclude retry rate: [[http://54.215.155.53/android_failures.html?platform=" +android_version+"  <span id=\"failure_rate"+android_version+"\"></span>%]]<br/>");
-            document.writeln("** "+android_version+" Total last week's failure rates <span id=\"failure_last_week"+android_version+"\"></span>%]]<br/>");
+            document.writeln("** "+android_version+" Total last week's failure rates <span id=\"failure_rate_last_week"+android_version+"\"></span>%]]<br/>");
             document.writeln("** "+android_version+" Total failure exclude retry <span id=\"failure_exclude_retry"+android_version+"\"></span>%]]<br/>");
 	    
 	    //second request which takes the week_before_last_week's date and last week's date  	 


### PR DESCRIPTION
History of revisions documented on https://bugzilla.mozilla.org/show_bug.cgi?id=1009198.
