### PR TITLE
fix the insert key error

### DIFF
--- a/src/updatedb.py
+++ b/src/updatedb.py
@@ -193,7 +193,7 @@ def uploadResults(data, branch, revision, date):
             snippets = fetch_json(url)
             if snippets:
                 for item in snippets[0]["blob"]:
-                    if not item["search_terms"] and len(item["search_term"]) < 1:
+                    if not item["search_terms"] and len(item["search_terms"]) < 1:
                         continue
                     filename = item['search_terms'][0]
                     if (filename.endswith('.js') or filename.endswith('.xul') or


### PR DESCRIPTION
we got KeyError with updatadb.py:
INFO:root:uploaded 1084/(1284) results for rev: 7d9629d35a32, branch: mozilla-inbound, date: 2016-06-22 00:59:52
INFO:root:Downloader 3: f8bee801a2a5 - 2016-06-21 22:43:12
ERROR:root:Error in Downloader 1
Traceback (most recent call last):
  File "src/updatedb.py", line 50, in run
    self.do_job(job_spec)
  File "src/updatedb.py", line 66, in do_job
    uploadResults(data, branch, revision, date)
  File "src/updatedb.py", line 203, in uploadResults
    if not item["search_terms"] and len(item["search_term"]) < 1:
KeyError: 'search_term'